### PR TITLE
Set framework to static link

### DIFF
--- a/ios/amap_location_flutter_plugin.podspec
+++ b/ios/amap_location_flutter_plugin.podspec
@@ -16,6 +16,7 @@ AMapLocation flutter plugin
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
 
+  s.static_framework = true
   s.ios.deployment_target = '8.0'
   s.dependency 'AMapLocation','~>2.6.7'
 end


### PR DESCRIPTION
项目中的ios/Podfile 里如果有 **use_frameworks!** ， build时会出现错误：
``` shell
the 'pods-runner' target has transitive dependencies that include statically linked binaries: (xxxx/ios/Pods/AMapLocation/AMapLocationKit.framework)
```

根据CocoaPods的说明，设置static_framework后，此错误会消除，经测试定位功能在应用中能正常运行。

reference: [CocoaPods description](https://blog.cocoapods.org/CocoaPods-1.4.0/).

Resolves #4 , Resolves #14 